### PR TITLE
feat:  add image viewer with keyboard navigation and accessibility features

### DIFF
--- a/index.html
+++ b/index.html
@@ -339,5 +339,135 @@
       </section>
     </section>
     <footer>&copy; Ruth Reed</footer>
+
+    <section
+      class="image-viewer"
+      id="image-viewer"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="image-viewer-title"
+      hidden
+    >
+      <button
+        class="image-viewer-close"
+        type="button"
+        aria-label="Close image viewer"
+      >
+        &times;
+      </button>
+      <button
+        class="image-viewer-nav image-viewer-previous"
+        type="button"
+        aria-label="Previous image"
+      >
+        &lsaquo;
+      </button>
+      <img id="image-viewer-image" src="" alt="" />
+      <button
+        class="image-viewer-nav image-viewer-next"
+        type="button"
+        aria-label="Next image"
+      >
+        &rsaquo;
+      </button>
+      <p id="image-viewer-title"></p>
+    </section>
+
+    <script>
+      // Get references to the image viewer elements and the gallery images.
+      const imageViewer = document.querySelector("#image-viewer");
+      const imageViewerImage = document.querySelector("#image-viewer-image");
+      const imageViewerTitle = document.querySelector("#image-viewer-title");
+      const imageViewerClose = document.querySelector(".image-viewer-close");
+      const imageViewerPrevious = document.querySelector(
+        ".image-viewer-previous"
+      );
+      const imageViewerNext = document.querySelector(".image-viewer-next");
+      const galleryImages = Array.from(
+        document.querySelectorAll(".grid-item img")
+      );
+      
+      // Keep track of the currently displayed image index in the viewer.
+      let currentImageIndex = 0;
+
+      // Updates the fullscreen viewer with the image and title at the given index.
+      function showImage(index) {
+        // Wrap the index around if it's out of bounds.
+        currentImageIndex =
+          (index + galleryImages.length) % galleryImages.length;
+        const image = galleryImages[currentImageIndex];
+        const title =
+          image.closest(".grid-item").querySelector("span").textContent;
+
+        imageViewerImage.src = image.src;
+        imageViewerImage.alt = image.alt;
+        imageViewerTitle.textContent = title;
+      }
+
+      // Opens the fullscreen viewer and shows the selected gallery image.
+      function openImageViewer(index) {
+        showImage(index);
+        imageViewer.hidden = false;
+        document.body.classList.add("viewer-open");
+        imageViewerClose.focus();
+      }
+
+      // Hides the fullscreen viewer and clears the displayed image.
+      function closeImageViewer() {
+        imageViewer.hidden = true;
+        imageViewerImage.src = "";
+        document.body.classList.remove("viewer-open");
+      }
+
+      // Moves the fullscreen viewer to the previous gallery image.
+      function showPreviousImage() {
+        showImage(currentImageIndex - 1);
+      }
+
+      // Moves the fullscreen viewer to the next gallery image.
+      function showNextImage() {
+        showImage(currentImageIndex + 1);
+      }
+      
+      // Add click and keyboard event listeners to each gallery image to open the viewer.
+      galleryImages?.forEach((image, index) => {
+        image.tabIndex = 0;
+        image.setAttribute("role", "button");
+        image.setAttribute("aria-label", `Open ${image.alt}`);
+
+        image.addEventListener("click", () => openImageViewer(index));
+        image.addEventListener("keydown", (event) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openImageViewer(index);
+          }
+        });
+      });
+
+      // Add event listeners for the viewer controls and background click.
+      imageViewerClose.addEventListener("click", closeImageViewer);
+      imageViewerPrevious.addEventListener("click", showPreviousImage);
+      imageViewerNext.addEventListener("click", showNextImage);
+      imageViewer.addEventListener("click", (event) => {
+        if (event.target === imageViewer) {
+          closeImageViewer();
+        }
+      });
+
+      // Add keyboard navigation for the image viewer.
+      document.addEventListener("keydown", (event) => {
+        if (imageViewer.hidden) {
+          return;
+        }
+
+        if (event.key === "Escape") {
+          closeImageViewer();
+        } else if (event.key === "ArrowLeft") {
+          showPreviousImage();
+        } else if (event.key === "ArrowRight") {
+          showNextImage();
+        }
+      });
+    </script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -38,6 +38,10 @@ body {
   background-color: #240c0c;
 }
 
+body.viewer-open {
+  overflow: hidden;
+}
+
 .full-page-section {
   height: 100vh;
 }
@@ -195,10 +199,15 @@ img {
   opacity: 1;
 }
 
+.grid-item > img {
+  cursor: pointer;
+}
+
 .grid-item > span {
   position: absolute;
   font-size: small;
   font-weight: bold;
+  pointer-events: none;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -265,6 +274,80 @@ footer {
   background-color: #140000;
   height: 3rem;
   padding-left: 4rem;
+}
+
+.image-viewer[hidden] {
+  display: none;
+}
+
+.image-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(8, 0, 0, 0.95);
+  padding: 3rem 1rem 5rem;
+}
+
+.image-viewer img {
+  max-width: calc(100% - 5rem);
+  max-height: 100%;
+  object-fit: contain;
+}
+
+#image-viewer-title {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(90vw, 44rem);
+  text-align: center;
+  font-weight: 700;
+}
+
+.image-viewer-close {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  color: white;
+  background: rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.image-viewer-close:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.image-viewer-nav {
+  position: fixed;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2.5rem;
+  height: 4rem;
+  color: white;
+  background: rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.image-viewer-nav:hover {
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.image-viewer-previous {
+  left: 1rem;
+}
+
+.image-viewer-next {
+  right: 1rem;
 }
 
 /* Media queries */


### PR DESCRIPTION
 ## Summary
 - Adds a fullscreen viewer for gallery images
 - Displays the selected image title centered at the bottom
 - Adds previous/next arrow controls for navigating all gallery images
 - Supports keyboard controls: Enter/Space to open, Escape to close, Left/Right arrows to navigate
 - Adds brief comments explaining the image viewer functions

It uses a mix of JavaScript and CSS classes to achieve the image viewer effect.
 
 ## Testing
 - Checked the final diff for whitespace issues
 - Reviewed editor diagnostics

Desktop view:
<img width="1126" height="810" alt="image" src="https://github.com/user-attachments/assets/90f03402-1df7-4724-9a9d-8ea4b0c82686" />

Mobile View:
<img width="499" height="817" alt="image" src="https://github.com/user-attachments/assets/407789ce-8847-4bee-b3c7-06d5d78e9067" />
